### PR TITLE
Combined BMP RLE decoders

### DIFF
--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -56,8 +56,8 @@ The :py:meth:`~PIL.Image.open` method sets the following
 :py:attr:`~PIL.Image.Image.info` properties:
 
 **compression**
-    Set to ``bmp_rle8`` if the file is a 256-color run-length encoded image.
-    Set to ``bmp_rle4`` if the file is a 16-color run-length encoded image.
+    Set to 1 if the file is a 256-color run-length encoded image.
+    Set to 2 if the file is a 16-color run-length encoded image.
 
 DDS
 ^^^


### PR DESCRIPTION
Two suggestions for https://github.com/python-pillow/Pillow/pull/6674

1. Corrected the BMP compression setting in the documentation. This was already incorrect in the documentation.
```python
with Image.open("Tests/images/hopper_rle4.bmp") as im:
        print(im.info["compression"])
```
prints 2.

2. I noticed that you copied much of the existing BMP RLE decoder, so I've combined your decoder with the existing decoder to reduce duplicate code.